### PR TITLE
Second pass at OCSF object mappings

### DIFF
--- a/objects/account.json
+++ b/objects/account.json
@@ -1,6 +1,6 @@
 {
   "caption": "Account",
-  "description": "The account object describes details about the account that was the source of the activity.",
+  "description": "The account object describes details about the account that was the source of the activity. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:UserAccount/'>d3f:UserAccount</a> and D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:CloudUserAccount/'>d3f:CloudUserAccount</a>.",
   "name": "account",
   "extends": "entity",
   "attributes": {

--- a/objects/analytic.json
+++ b/objects/analytic.json
@@ -1,7 +1,7 @@
 {
     "caption": "Analytic",
     "name": "analytic",
-    "description": "The analytic technique associated with a finding.",
+    "description": "The analytic technique associated with a finding. May be used in D3FEND Techniques.",
   "extends": "entity",
     "attributes": {
       "category": {

--- a/objects/analytic.json
+++ b/objects/analytic.json
@@ -1,7 +1,7 @@
 {
     "caption": "Analytic",
     "name": "analytic",
-    "description": "The analytic technique associated with a finding. May be used in D3FEND Techniques.",
+    "description": "The analytic technique associated with a finding.",
   "extends": "entity",
     "attributes": {
       "category": {

--- a/objects/authorization.json
+++ b/objects/authorization.json
@@ -1,6 +1,6 @@
 {
   "caption": "Authorization Information",
-  "description": "This object provides details such as authorization outcome, associated policies related to activity/event.",
+  "description": "This object provides details such as authorization outcome, associated policies related to activity/event. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Authorization/'>d3f:Authorization</a>.",
   "extends": "object",
   "name": "authorization",
   "attributes": {

--- a/objects/container.json
+++ b/objects/container.json
@@ -2,7 +2,7 @@
   "caption": "Container",
   "observable": 27,
   "name": "container",
-  "description": "The Container object describes an instance of a specific container. A container is a prepackaged, portable system image that runs isolated on an existing system using a container runtime like containerd. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:ContainerImage/'>d3f:ContainerImage</a>.",
+  "description": "The Container object describes an instance of a specific container. A container is a prepackaged, portable system image that runs isolated on an existing system using a container runtime like containerd. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:ContainerProcess/'>d3f:ContainerProcess</a>.",
   "extends": "object",
   "attributes": {
     "name": {

--- a/objects/container.json
+++ b/objects/container.json
@@ -2,7 +2,7 @@
   "caption": "Container",
   "observable": 27,
   "name": "container",
-  "description": "The Container object describes an instance of a specific container. A container is a prepackaged, portable system image that runs isolated on an existing system using a container runtime like containerd.",
+  "description": "The Container object describes an instance of a specific container. A container is a prepackaged, portable system image that runs isolated on an existing system using a container runtime like containerd. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:ContainerImage/'>d3f:ContainerImage</a>.",
   "extends": "object",
   "attributes": {
     "name": {

--- a/objects/device_hw_info.json
+++ b/objects/device_hw_info.json
@@ -1,7 +1,7 @@
 {
   "caption": "Device Hardware Info",
   "name": "device_hw_info",
-  "description": "The device hardware information.",
+  "description": "The device hardware information. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:HardwareDevice/'>d3f:HardwareDevice</a>.",
   "extends": "object",
   "attributes": {
     "bios_date": {

--- a/objects/fingerprint.json
+++ b/objects/fingerprint.json
@@ -1,7 +1,7 @@
 {
   "caption": "Fingerprint",
   "name": "fingerprint",
-  "description": "The fingerprint object describes the algorithm and value of digital fingerprint. A fingerprint is a short sequence of bytes used to identify a longer public key or file content.",
+  "description": "The fingerprint object describes the algorithm and value of digital fingerprint. A fingerprint is a short sequence of bytes used to identify a longer public key or file content. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:FileHash/'>d3f:FileHash</a>.",
   "extends": "object",
   "attributes": {
     "algorithm": {

--- a/objects/fingerprint.json
+++ b/objects/fingerprint.json
@@ -1,7 +1,7 @@
 {
   "caption": "Fingerprint",
   "name": "fingerprint",
-  "description": "The fingerprint object describes the algorithm and value of digital fingerprint. A fingerprint is a short sequence of bytes used to identify a longer public key or file content. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:FileHash/'>d3f:FileHash</a>.",
+  "description": "The fingerprint object describes the algorithm and value of digital fingerprint. A fingerprint is a short sequence of bytes used to identify a longer public key or file content. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:DigitalFingerprint/'>d3f:DigitalFingerprint</a>.",
   "extends": "object",
   "attributes": {
     "algorithm": {

--- a/objects/group.json
+++ b/objects/group.json
@@ -1,7 +1,7 @@
 {
   "caption": "Group",
   "name": "group",
-  "description": "The group object associated with an entity such as user, policy, or device.",
+  "description": "The group object associated with an entity such as user, policy, or device. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:UserGroup/'>d3f:UserGroup</a>.",
   "extends": "entity",
   "attributes": {
     "desc": {

--- a/objects/group.json
+++ b/objects/group.json
@@ -1,7 +1,7 @@
 {
   "caption": "Group",
   "name": "group",
-  "description": "The group object associated with an entity such as user, policy, or device. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:UserGroup/'>d3f:UserGroup</a>.",
+  "description": "The group object associated with an entity such as user, policy, or device. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:EntityGroup/'>d3f:EntityGroup</a>.",
   "extends": "entity",
   "attributes": {
     "desc": {

--- a/objects/http_cookie.json
+++ b/objects/http_cookie.json
@@ -1,7 +1,7 @@
 {
   "caption": "HTTP Cookie",
   "name": "http_cookie",
-  "description": "An HTTP cookie (web cookie, browser cookie) is a small piece of data that a server sends to a user's web browser.",
+  "description": "An HTTP cookie (web cookie, browser cookie) is a small piece of data that a server sends to a user's web browser. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:SessionCookie/'>d3f:SessionCookie</a>.",
   "extends": "object",
   "attributes": {
     "name": {

--- a/objects/job.json
+++ b/objects/job.json
@@ -1,7 +1,7 @@
 {
   "caption": "Job",
   "name": "job",
-  "description": "The job object describes the name, command line and state of a scheduled job or task. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:TaskSchedule/'>d3f:TaskSchedule</a>.",
+  "description": "The job object describes the name, command line and state of a scheduled job or task. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:ScheduledTask/'>d3f:ScheduledTask</a>.",
   "extends": "object",
   "attributes": {
     "cmd_line": {

--- a/objects/job.json
+++ b/objects/job.json
@@ -1,7 +1,7 @@
 {
   "caption": "Job",
   "name": "job",
-  "description": "The job object describes the name, command line and state of a scheduled job or task.",
+  "description": "The job object describes the name, command line and state of a scheduled job or task. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:TaskSchedule/'>d3f:TaskSchedule</a>.",
   "extends": "object",
   "attributes": {
     "cmd_line": {

--- a/objects/registry_value.json
+++ b/objects/registry_value.json
@@ -1,6 +1,6 @@
 {
   "caption": "Registry Value",
-  "description": "The registry value object describes a Windows registry value.",
+  "description": "The registry value object describes a Windows registry value. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:WindowsRegistry/'>d3f:WindowsRegistry</a>.",
   "extends": "object",
   "name": "registry_value",
   "observable": 29,

--- a/objects/registry_value.json
+++ b/objects/registry_value.json
@@ -1,6 +1,6 @@
 {
   "caption": "Registry Value",
-  "description": "The registry value object describes a Windows registry value. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:WindowsRegistry/'>d3f:WindowsRegistry</a>.",
+  "description": "The registry value object describes a Windows registry value. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:WindowsRegistryValue/'>d3f:WindowsRegistryValue</a>.",
   "extends": "object",
   "name": "registry_value",
   "observable": 29,


### PR DESCRIPTION
A few more challenging mappings now that the low-hanging fruit is gone.

Notes:
- d3f:UserAccount is now mapped to both 'account' and 'user'
- Correct wording for 'analytic'?
- d3f:ContainerImage is part of 'container' and 'image'
- d3f:UserGroup is not present on https://next.d3fend.mitre.org/ atm